### PR TITLE
[ISSUE-25] Extract Date format strings into separate function

### DIFF
--- a/bash/core.bash
+++ b/bash/core.bash
@@ -273,6 +273,51 @@ function opal:file_has_set_gid {
 
 ################################################################################
 #
+#   Date Functions
+#
+################################################################################
+
+function opal:get_date_format {
+    local format_name
+
+    format_name="$1"
+    if [[ $format_name == "unix" ]]; then
+        echo "%s"
+    elif [[ $format_name == "opal-date" ]]; then
+        echo "%Y %b %d %a"
+    elif [[ $format_name == "opal-datetime" ]]; then
+        echo "%Y %b %d %a %H:%M"
+    elif [[ $format_name == "opal-timestamp" ]]; then
+        echo "%Y %b %d %a %H:%M:%S%z"
+    elif [[ $format_name == "iso-date" ]]; then
+        echo "%Y-%m-%d"
+    elif [[ $format_name == "iso-timestamp" ]]; then
+        echo "%Y-%m-%dT%H:%M:%S%z"
+    elif [[ $format_name == "world-date" ]]; then
+        echo "%d.%m.%Y"
+    elif [[ $format_name == "world-datetime" ]]; then
+        echo "%d.%m.%Y %H:%M"
+    elif [[ $format_name == "us-date" ]]; then
+        echo "%m/%d/%Y"
+    elif [[ $format_name == "us-datetime" ]]; then
+        echo "%m/%d/%Y %l:%M%p"
+    elif [[ $format_name == "us-timestamp" ]]; then
+        echo "%m/%d/%Y %l:%M:%S%p %z"
+    elif [[ $format_name == "filename-date" ]]; then
+        echo "%Y-%m-%d"
+    elif [[ $format_name == "filename-datetime" ]]; then
+        echo "%Y-%m-%d-%H-%M"
+    elif [[ $format_name == "filename-timestamp" ]]; then
+        echo "%Y-%m-%d-%H-%M-%S"
+    else
+        opal:std_error "Your specified format name is not available"
+        return 1
+    fi
+}
+
+
+################################################################################
+#
 #   Documentation
 #
 ################################################################################

--- a/bash/core.bash
+++ b/bash/core.bash
@@ -316,16 +316,16 @@ function opal:get_date_format {
 }
 
 function opal:today {
-    local date_format
     local format_name
-    local format_style
+    local date_format
 
     format_name="opal-datetime"
     if opal:is_set $1; then
         format_name="$1"
     fi
 
-    format_style=""
+    date_format=$(opal:get_date_format "$format_name")
+    echo "$(date +"${date_format}")"
     if opal:is_set "$2"; then
         format_style="$2"
     fi

--- a/bash/core.bash
+++ b/bash/core.bash
@@ -326,12 +326,26 @@ function opal:today {
 
     date_format=$(opal:get_date_format "$format_name")
     echo "$(date +"${date_format}")"
-    if opal:is_set "$2"; then
-        format_style="$2"
-    fi
+}
 
-    date_format=$(opal:get_date_format "$format_name" "$format_style")
-    echo "$(date +"${date_format}")"
+function opal:someday() {
+    local unix_time
+    local format_name
+    local date_format
+
+    if opal:is_unset "$1"; then
+        echo "You forgot to the time in unix seconds"
+        return 1
+    fi
+    unix_time=$1
+
+    format_name="opal-datetime"
+    if opal:is_set "$2"; then
+        format_name="$2"
+    fi
+    date_format="+$(opal:get_date_format "${format_name}")"
+
+    date -r "${unix_time}" "${date_format}"
 }
 
 

--- a/bash/core.bash
+++ b/bash/core.bash
@@ -315,6 +315,25 @@ function opal:get_date_format {
     fi
 }
 
+function opal:today {
+    local date_format
+    local format_name
+    local format_style
+
+    format_name="opal-datetime"
+    if opal:is_set $1; then
+        format_name="$1"
+    fi
+
+    format_style=""
+    if opal:is_set "$2"; then
+        format_style="$2"
+    fi
+
+    date_format=$(opal:get_date_format "$format_name" "$format_style")
+    echo "$(date +"${date_format}")"
+}
+
 
 ################################################################################
 #

--- a/bash/util.bash
+++ b/bash/util.bash
@@ -122,6 +122,7 @@ function mach() {
 # ncal3 - Display the previous month, current month, and next month vertically
 #
 function ncal3() {
+    opal:std_error 'Deprecated. Will be moving to the "opal:" namespace for v3'
     ncal -my $(date -v-1m "+%m %Y")
     _n
     ncal
@@ -133,6 +134,7 @@ function ncal3() {
 # preamble - Display a block message to the user about who and where they are
 #
 function preamble() {
+    opal:std_error 'Deprecated. Will be moving to the "opal:" namespace for v3'
     name=$(whoami)
     host=$(hostname -f)
     thisday=$(today default)
@@ -198,6 +200,7 @@ function spacer {
 # @param String Optional $type Allowed values: text, numeric
 #
 function today() {
+    opal:std_error 'Deprecated. Will be moving to the "opal:" namespace for v3'
 
     case $1 in
     'unix')
@@ -243,6 +246,7 @@ function today() {
 
 
 function filedate() {
+    opal:std_error 'Deprecated. Will be moving to the "opal:" namespace for v3'
     if [[ $1 == "time" ]]; then
         echo $(date +"%Y-%m-%d-%H-%M-%S")
     else
@@ -254,6 +258,7 @@ function filedate() {
 # filedate_to_day - Convert file stamp to determine the day of the week
 #
 function filedate_to_day {
+    opal:std_error 'Deprecated. Will be moving to the "opal:" namespace for v3'
     if [[ $1 == "time" ]]; then
         date -j -f '%Y-%m-%d-%H-%M-%S' $2 '+%a'
     else
@@ -291,6 +296,7 @@ get_os() {
 #          and display LS_COLORS accordinly
 #
 termbg() {
+    opal:std_error 'Deprecated. Will be moving to the "opal:" namespace for v3'
     if [[ -z $TERM_BG ]]; then
         TERM_BG="dark"
         echo "the terminal background is ${TERM_BG}"
@@ -346,6 +352,7 @@ termbg() {
 # monday_date - Determine the date for Mon of the current week
 #
 function monday_date {
+    opal:std_error 'Deprecated. Will be moving to the "opal:" namespace for v3'
     day_of_week=$(date '+%a')
     format='+%Y %b %d %a'
 
@@ -371,6 +378,7 @@ function monday_date {
 # sunday_date - Determine the date for Sunday of the current week
 #
 function sunday_date {
+    opal:std_error 'Deprecated. Will be moving to the "opal:" namespace for v3'
     day_of_week=$(date '+%a')
     format='+%Y %b %d %a'
 

--- a/bash/util.bash
+++ b/bash/util.bash
@@ -241,16 +241,6 @@ function today() {
     esac
 }
 
-function show_date() {
-
-    if [[ -z $1 ]]; then
-        echo "You forgot to the time in unix seconds"
-        return 1
-    fi
-    unixtime=$1
-
-    date -r $unixtime
-}
 
 function filedate() {
     if [[ $1 == "time" ]]; then


### PR DESCRIPTION
This creates a new function — `opal:get_date_format` — that can be leveraged any time you need to display a date. A human-understandable name is used to retrieve the corresponding date format. When the suffix `-date` is used, its precision is to the day of the month. When `-datetime` is used, the precision is to the minute. Finally, when the suffix `-timestamp` is used, the precision to the minute and _may_ include the timezone.

Additionally, 2 date functions are used to leverage it, namely `opal:today` and `opal:someday` which can be passed the format name to display the desired date output.   